### PR TITLE
Update platformio.ini to not set core_dir to a non standard location

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 
 [platformio]
 src_dir      = Marlin
-core_dir     = D:/.platformio
+#core_dir     = D:/.platformio
 boards_dir   = buildroot/share/PlatformIO/boards
 default_envs = tronxy_stm32f446
 include_dir  = Marlin


### PR DESCRIPTION

\### Description

<!--

Change Core Dir value to be commented by default.

-->

### Requirements

No requirements

### Benefits

Enables firmware to build by default on most systems.

### Configurations



### Related Issues


